### PR TITLE
Fix AsyncEventListenerType base class

### DIFF
--- a/src/sublime_aio.py
+++ b/src/sublime_aio.py
@@ -5,6 +5,7 @@ import io
 import os
 import sys
 import traceback
+from abc import ABCMeta
 from inspect import iscoroutinefunction
 from threading import Event, Lock, Thread
 from time import monotonic as now
@@ -427,7 +428,7 @@ class ViewCommand(sublime_plugin.TextCommand):
         raise NotImplementedError
 
 
-class AsyncEventListenerType(type):
+class AsyncEventListenerType(ABCMeta):
     """
     This class describes an asynchronous event listener meta class.
 
@@ -558,7 +559,7 @@ class ViewEventListener(sublime_plugin.ViewEventListener, metaclass=AsyncEventLi
     pass
 
 
-class AsyncTextChangeListenerType(type):
+class AsyncTextChangeListenerType(ABCMeta):
     """
     This class describes an asynchronous text change listener meta class.
 


### PR DESCRIPTION
Resolves #9 

This PR inherits `AsyncEventListenerType` from `ABCMeta` to enable listeners to inherit from custom `ABC` interfaces.

Example

```py
import sublime_aio
from abc import ABC
from abc import abstractmethod

class MyAbstractViewListener(ABC):

    @abstractmethod
    async def on_modified(self):
        raise NotImplementedError

class MyViewListener(sublime_aio.ViewEventListener, MyAbstractViewListener):

    async def on_modified(self):
        print(f"{self.view} got modified.")
```