### PR TITLE
Export call_soon_threadsafe

### DIFF
--- a/src/sublime_aio.py
+++ b/src/sublime_aio.py
@@ -42,6 +42,7 @@ __all__ = [
     "__version__",
     "active_window",
     "ApplicationCommand",
+    "call_soon_threadsafe",
     "debounced",
     "EventListener",
     "InputCancelledError",


### PR DESCRIPTION
This commit adds `call_soon_threadsafe` to list of `__all__` exported objects.