### PR TITLE
Tweak completion task cancellation

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,30 @@ class CompletionListener(sublime_aio.ViewEventListener):
 > not designed to be re-used by plugin code!
 
 
+### Completion Cancellation
+
+Any pending `on_query_completions` coroutine is cancelled,
+as soon as a new event is received from Sublime Text,
+before a new completion query task is scheduled.
+
+To send cancellation notificaitons to external applicaitons,
+catch `asyncio.CancelledError`.
+
+```py
+import sublime_aio
+
+
+class CompletionListener(sublime_aio.ViewEventListener):
+
+    async def on_query_completions(self, prefix, locations):
+        try:
+            return await get_completions_from_server()
+        except asyncio.CancelledError:
+            await send_cancel_notification_to_server()
+            return []
+```
+
+
 ## Text Change Listener
 
 ```py

--- a/src/sublime_aio.py
+++ b/src/sublime_aio.py
@@ -572,7 +572,6 @@ class AsyncEventListenerType(ABCMeta):
 
             # wrap `async def on_query_completions()` in sync method of same name
             elif attr_name == "on_query_completions" and iscoroutinefunction(attr_value):
-                future = None
                 task = None
                 completions_coro_func: Callable[
                     ..., Coroutine[object, object, CompletionsReturnVal]
@@ -605,9 +604,7 @@ class AsyncEventListenerType(ABCMeta):
                     *args: P.args, **kwargs: P.kwargs
                 ) -> sublime.CompletionList:
                     clist = sublime.CompletionList()
-                    future = run_coroutine(
-                        query_completions(clist, completions_coro_func(*args, **kwargs))
-                    )
+                    call_coroutine(query_completions(clist, completions_coro_func(*args, **kwargs)))
                     return clist
 
                 attrs[attr_name] = on_query_completions

--- a/src/sublime_aio.py
+++ b/src/sublime_aio.py
@@ -573,6 +573,7 @@ class AsyncEventListenerType(ABCMeta):
             # wrap `async def on_query_completions()` in sync method of same name
             elif attr_name == "on_query_completions" and iscoroutinefunction(attr_value):
                 future = None
+                task = None
                 completions_coro_func: Callable[
                     ..., Coroutine[object, object, CompletionsReturnVal]
                 ] = attr_value
@@ -581,8 +582,13 @@ class AsyncEventListenerType(ABCMeta):
                     clist: sublime.CompletionList,
                     coro: Coroutine[object, object, CompletionsReturnVal],
                 ) -> None:
+                    nonlocal task
+                    if task is not None:
+                        task.cancel()
+                        task = None
+
                     try:
-                        completions = await coro
+                        completions = await (task := asyncio.create_task(coro))
                         if isinstance(completions, sublime.CompletionList):
                             clist.set_completions(completions.completions or [], completions.flags)
                         elif isinstance(completions, tuple):
@@ -598,11 +604,6 @@ class AsyncEventListenerType(ABCMeta):
                 def on_query_completions(
                     *args: P.args, **kwargs: P.kwargs
                 ) -> sublime.CompletionList:
-                    nonlocal future
-
-                    if future:
-                        future.cancel()
-
                     clist = sublime.CompletionList()
                     future = run_coroutine(
                         query_completions(clist, completions_coro_func(*args, **kwargs))


### PR DESCRIPTION
Resolves #31

This PR moves completion cancellation from synchronous to asynchronous code in order to ensure a pending task is cancelled before a new one is started.

A plugin can catch `asyncio.CancelledError` to notify external applications before a new request is sent.

Tested with the following code to ensure cancellation is executed, before next completion request, without however delaying execution.

```py
import asyncio
import sublime_aio


class AsyncTestEventListener(sublime_aio.ViewEventListener):
    k = 0

    async def on_query_completions(self, pt, prefix):
        try:
            self.k += 1
            print(f"Completion {self.k}")
            await asyncio.sleep(4.0)
        except asyncio.CancelledError:
            print(f"Cancelling {self.k}")
            await asyncio.sleep(2.0)
            print(f"Cancelled {self.k}")
            raise

```

Note: Cancelled tasks can't be awaited, nor can cancellation request.
